### PR TITLE
Use nemo-desktop with nautilus > 3.30

### DIFF
--- a/UnityTweakTool/section/dynamic.py
+++ b/UnityTweakTool/section/dynamic.py
@@ -39,3 +39,11 @@ if "org.gnome.desktop.peripherals" not in schema_list:
     touchpad_schema = 'settings-daemon'
 else:
     touchpad_schema = 'desktop'
+
+
+# Desktop feature was removed in nautilus >=3.28. So we use nemo to draw desktop icons.
+#See https://bugs.launchpad.net/ubuntu/+source/unity/+bug/1814506
+if "org.gnome.nautilus.desktop" not in schema_list:
+    desktop_schema = 'org.nemo.desktop'
+else:
+    desktop_schema = 'org.gnome.nautilus.desktop'

--- a/UnityTweakTool/section/system.py
+++ b/UnityTweakTool/section/system.py
@@ -44,7 +44,7 @@ System=Section(ui='system.ui',id='nb_desktop_settings')
 tb_home_folder= ToggleButton({
     'id'        : 'tb_home_folder',
     'builder'   : System.builder,
-    'schema'    : 'org.gnome.nautilus.desktop',
+    'schema'    : dynamic.desktop_schema,
     'path'      : None,
     'key'       : 'home-icon-visible',
     'type'      : 'boolean',
@@ -55,7 +55,7 @@ tb_home_folder= ToggleButton({
 tb_network= ToggleButton({
     'id'        : 'tb_network',
     'builder'   : System.builder,
-    'schema'    : 'org.gnome.nautilus.desktop',
+    'schema'    : dynamic.desktop_schema,
     'path'      : None,
     'key'       : 'network-icon-visible',
     'type'      : 'boolean',
@@ -66,7 +66,7 @@ tb_network= ToggleButton({
 tb_trash= ToggleButton({
     'id'        : 'tb_trash',
     'builder'   : System.builder,
-    'schema'    : 'org.gnome.nautilus.desktop',
+    'schema'    : dynamic.desktop_schema,
     'path'      : None,
     'key'       : 'trash-icon-visible',
     'type'      : 'boolean',
@@ -77,7 +77,7 @@ tb_trash= ToggleButton({
 tb_devices= ToggleButton({
     'id'        : 'tb_devices',
     'builder'   : System.builder,
-    'schema'    : 'org.gnome.nautilus.desktop',
+    'schema'    : dynamic.desktop_schema,
     'path'      : None,
     'key'       : 'volumes-visible',
     'type'      : 'boolean',

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Depends: ${python3:Depends},
  unity (>= 6.8),
  python3-xdg,
  python3-cairo,
- unity-webapps-common,
  ${misc:Depends}
 Description: configuration tool for the Unity desktop environment
  Unity Tweak Tool is a settings manager for the Unity desktop.


### PR DESCRIPTION
Desktop feature was removed in nautilus >=3.28. So we use nemo to draw desktop icons.
#See https://bugs.launchpad.net/ubuntu/+source/unity/+bug/1814506

Drop unity-webapps-common dependency. It was removed in artful