### PR TITLE
Fixup "Use nemo-desktop with nautilus > 3.30"

### DIFF
--- a/UnityTweakTool/section/spaghetti/gsettings.py
+++ b/UnityTweakTool/section/spaghetti/gsettings.py
@@ -108,7 +108,7 @@ sound = canonical('indicator.sound')
 
 antialiasing = gnome('settings-daemon.plugins.xsettings')
 background = gnome('desktop.background')
-desktop = gnome('nautilus.desktop')
+desktop = dynamic.desktop_schema
 interface = gnome('desktop.interface')
 lockdown = gnome('desktop.lockdown')
 wm = gnome('desktop.wm.preferences')


### PR DESCRIPTION
Commit 0d0e74da0d2250bfa324eaf71a1cb9be8813d422 changed the code to use nemo to draw desktop icons for nautilus > 3.30, but was still referring to it in `gsettings.py`.