### PR TITLE
Removed 'metacity-1' from 'required' in theme.py

### DIFF
--- a/UnityTweakTool/section/spaghetti/theme.py
+++ b/UnityTweakTool/section/spaghetti/theme.py
@@ -55,7 +55,7 @@ class Themesettings ():
             userthemes=[]
         allthemes=systemthemes+userthemes
         allthemes.sort()
-        required=['gtk-2.0','gtk-3.0','metacity-1']
+        required=['gtk-2.0','gtk-3.0']
         self.gtkthemes={}
         self.windowthemes={}
         for theme in allthemes:


### PR DESCRIPTION
I've removed `metacity-1` from `required` in `theme.py`, as many Unity7 themes do not have the `metacity-1` directory (including `yaru-theme-unity`). Thus, many people had to install `gnome-tweaks` to use those themes. With this, they'll be able to use `unity-tweak-tool` with themes without the `metacity-1` directory.